### PR TITLE
Exclude parquet and jsonl files from in-solidarity check

### DIFF
--- a/.github/in-solidarity.yml
+++ b/.github/in-solidarity.yml
@@ -6,3 +6,6 @@ rules:
     level: warning
     alternatives:
       - solidaryWorks
+ignore:
+  - "**/*.parquet"
+  - "**/*.jsonl"


### PR DESCRIPTION
Extend in-solidarity config to exclude ".parquet" and ".jsonl" files from the inclusive language check